### PR TITLE
Allow registering custom menus for utilities 

### DIFF
--- a/csharp/Yaskawa/Ext/Pendant.cs
+++ b/csharp/Yaskawa/Ext/Pendant.cs
@@ -138,9 +138,18 @@ namespace Yaskawa.Ext
         {
             client.registerTranslationData(id, locale, translationData, translationName);
         }
-       public void registerUtilityWindow(string identifier, string itemtype, string menuitemname, string windowtitle) 
+
+        public void registerUtilityMenu(string menuName, string menuText, string menuIcon) 
+        {
+            client.registerUtilityMenu(id, menuName, menuText, menuIcon);
+        }
+        public void unregisterUtilityMenu(string menuName) 
+        {
+            client.unregisterUtilityMenu(id, menuName);
+        }
+       public void registerUtilityWindow(string identifier, string itemtype, string menuitemname, string windowtitle, string menuName) 
        {
-           client.registerUtilityWindow(id, identifier, itemtype, menuitemname, windowtitle);
+           client.registerUtilityWindow(id, identifier, itemtype, menuitemname, windowtitle, menuName);
        }
        public void unregisterUtilityWindow(String identifier)
        {

--- a/docs/en/gen-html/extension.html
+++ b/docs/en/gen-html/extension.html
@@ -562,7 +562,9 @@ otherwise.
 </td></tr>
 </table></div>
 <div class="definition"><h3 id="Enum_OperationMode">Enumeration: OperationMode</h3>
-<br/><table class="table-bordered table-striped table-condensed">
+<pre>Automatic - Play
+Manual - Teach
+</pre><br/><br/><table class="table-bordered table-striped table-condensed">
 <tr><td><code>Automatic</code></td><td><code>0</code></td><td>
 </td></tr>
 <tr><td><code>Manual</code></td><td><code>1</code></td><td>
@@ -1396,6 +1398,8 @@ is the single-point-of-control.
                         <code>set&lt;<code>string</code>&gt;</code> permissions)
     throws <code><a href="#Struct_IllegalArgument">IllegalArgument</a></code>
 </pre><pre>Request specified permissions.
+"jobcontrol" permission is used to manipulate jobs
+"networking" permission is used to connect to external networks
 </pre><br/></div><div class="definition"><h4 id="Fn_Controller_havePermission">Function: Controller.havePermission</h4>
 <pre><code>bool</code> havePermission(<code><a href="#Struct_ControllerID">ControllerID</a></code> c,
                     <code>string</code> permission)
@@ -1470,11 +1474,11 @@ Idle - no jobs are running
 Step - a job is run line-for-line.
 Once - a job is run from the beginning to the end.
 Continuous - a job is run indefinitely from the beginning to the end.
-(API 3.0 and Later)
+(API Version 3.0 and Later)
 </pre><br/></div><div class="definition"><h4 id="Fn_Controller_setPlaybackCycle">Function: Controller.setPlaybackCycle</h4>
 <pre><code>void</code> setPlaybackCycle(<code><a href="#Struct_ControllerID">ControllerID</a></code> c,
                       <code><a href="#Enum_PlaybackCycle">PlaybackCycle</a></code> cycle)
-</pre><pre>Sets the playback cycle mode. (API 3.0 and Later)
+</pre><pre>Sets the playback cycle mode. (API Version 3.0 and Later)
 </pre><br/></div><div class="definition"><h4 id="Fn_Controller_run">Function: Controller.run</h4>
 <pre><code>void</code> run(<code><a href="#Struct_ControllerID">ControllerID</a></code> c)
 </pre><pre>Run the current robot job from the current line.  Requires Servos engaged & Automatic/Play operation and 'jobcontrol' permission.
@@ -1840,7 +1844,8 @@ NB: Indices (map keys) may not be sequential. Returned map may be empty.
                   <code><a href="#Struct_CoordinateFrame">CoordinateFrame</a></code> f)
     throws <code><a href="#Struct_IllegalArgument">IllegalArgument</a></code>
 </pre><pre>Set the specified User Frame to the provided values
-Future: Not implemented yet
+If a user frame at the selected index does not exist it is created. Otherwise, the user frame at the selected index is replaced.
+(API Version 3.0 and later)
 </pre><br/></div><div class="definition"><h4 id="Fn_Controller_deleteUserFrame">Function: Controller.deleteUserFrame</h4>
 <pre><code>void</code> deleteUserFrame(<code><a href="#Struct_ControllerID">ControllerID</a></code> c,
                      <code><a href="#Struct_UserFrameIndex">UserFrameIndex</a></code> index)

--- a/extension.thrift
+++ b/extension.thrift
@@ -765,6 +765,9 @@ struct ControllerEvent {
     2: optional map<string,Any> props;
 }
 
+/**
+   Automatic - Play
+   Manual - Teach*/
 enum OperationMode { Automatic=0, Manual=1 }
 enum ServoState { Off=0, Ready=1, On=2 }
 enum PlaybackState { Run=0, Hold=1, Idle=2 }
@@ -930,7 +933,10 @@ service Controller
     //
     // Permissions
 
-    /** Request specified permissions. */
+    /** Request specified permissions. 
+    	* "jobcontrol" permission is used to manipulate jobs
+    	* "networking" permission is used to connect to external networks
+    */
     bool requestPermissions(1:ControllerID c, 2:set<string> permissions) throws (1:IllegalArgument e);
 
     /** Check permisions obtained. */
@@ -1027,11 +1033,11 @@ service Controller
         Step - a job is run line-for-line.
         Once - a job is run from the beginning to the end.
         Continuous - a job is run indefinitely from the beginning to the end.
-        (API 3.0 and Later)
+        (API Version 3.0 and Later)
      */
     PlaybackCycle playbackCycle(1:ControllerID c);
 
-    /**Sets the playback cycle mode. (API 3.0 and Later)*/
+    /**Sets the playback cycle mode. (API Version 3.0 and Later)*/
     void setPlaybackCycle(1:ControllerID c, 2:PlaybackCycle cycle);
 
     /** Run the current robot job from the current line.  Requires Servos engaged & Automatic/Play operation and 'jobcontrol' permission. */
@@ -1296,7 +1302,8 @@ service Controller
     UserFrameIndex newUserFrame(1:ControllerID c) throws (1:IllegalArgument e);
 
     /** Set the specified User Frame to the provided values 
-        Future: Not implemented yet  */
+        If a user frame at the selected index does not exist it is created. Otherwise, the user frame at the selected index is replaced.
+        (API Version 3.0 and later)*/
     void setUserFrame(1:ControllerID c, 2:UserFrameIndex index, 3:CoordinateFrame f) throws (1:IllegalArgument e);
 
     /** Delete a User Frame */

--- a/extension.thrift
+++ b/extension.thrift
@@ -510,15 +510,21 @@ service Pendant
     void registerTranslationData(1:PendantID p, 2:string locale, 3:binary translationData, 4:string translationName)
                           throws (1:IllegalArgument e);
 
-
+    /** Register a menu that utilities can be registered under **/
+    void registerUtilityMenu(1:PendantID p, 2:string menuName, 3:string menuText, 4:string menuIcon)
+                        throws (1:IllegalArgument e);
+    /** Unregisters a user added menu - All Utilities within the menu must be unregistered with 'unregisterUtilityWindow' first*/ 
+    void unregisterUtilityMenu(1:PendantID p, 2:string menuName)
+                        throws (1:IllegalArgument e);
     /** Register a Utility window with the UI.  
         The itemType references a previously registered YML item instantiated for the window
         UI content.
-        A main menu entry will automatically be added to the pendant UI, for opening the utility window.
+        The menuName refers to a previously registered menu that the utility will apear under on the 
+        main menu or if none is specified it will be under 'Utility'
     */
     void registerUtilityWindow(1:PendantID p, 2:string identifier, 
                                3:string itemType,
-                               4:string menuItemName, 5:string windowTitle)
+                               4:string menuItemName, 5:string windowTitle, 6:string menuName)
                           throws (1:IllegalArgument e);
 
     void unregisterUtilityWindow(1:PendantID p, 2:string identifier)

--- a/java/build.sh
+++ b/java/build.sh
@@ -20,7 +20,7 @@ javac -source 11 -target 11 -Xlint:deprecation -cp ../lib/libthrift-0.11.0.jar:.
 cd ..
 javac -source 11 -target 11 -Xlint:deprecation -Xlint:unchecked -cp lib/libthrift-0.11.0.jar:lib/slf4j-api.jar:gen-java yaskawa/ext/*.java
 cd gen-java
-jar cf ../yaskawa-ext-3.1.0.jar yaskawa
+jar cf ../yaskawa-ext-3.0.0.jar yaskawa
 cd ..
-jar uf yaskawa-ext-3.1.0.jar yaskawa
+jar uf yaskawa-ext-3.0.0.jar yaskawa
 

--- a/java/yaskawa/ext/Pendant.java
+++ b/java/yaskawa/ext/Pendant.java
@@ -174,12 +174,24 @@ public class Pendant
         }
     }
 
-
-
-    public void registerUtilityWindow(String identifier, String itemType, String menuItemName, String windowTitle) throws TException
+    public void registerUtilityMenu(String menuName, String menuTitle, String menuIcon) throws TException
     {
         synchronized(extension) {
-            client.registerUtilityWindow(id, identifier, itemType, menuItemName, windowTitle);
+            client.registerUtilityMenu(id, menuName, menuTitle, menuIcon);
+        }
+    }
+
+    public void unregisterUtilityMenu(String menuName) throws TException
+    {
+        synchronized(extension) {
+            client.unregisterUtilityMenu(id, menuName);
+        }
+    }
+    
+    public void registerUtilityWindow(String identifier, String itemType, String menuItemName, String windowTitle, String menuName) throws TException
+    {
+        synchronized(extension) {
+            client.registerUtilityWindow(id, identifier, itemType, menuItemName, windowTitle, menuName);
         }
     }
 


### PR DESCRIPTION
* Add method to thrift to allow for registering menus that utilities can be under.
* Add method for unregistering menus
* Update method for registering utilities to include a menuName that corresponds to a registered menu 
Example of custom menu:
![Screenshot from 2023-06-09 07-17-23](https://github.com/Yaskawa-Global/SmartPendantSDK/assets/127866402/5f839ad5-64d9-4db2-b487-470e5ddd67cb)
