### PR TITLE
Allow registering custom utility Menus

### DIFF
--- a/csharp/Yaskawa/Ext/Pendant.cs
+++ b/csharp/Yaskawa/Ext/Pendant.cs
@@ -138,9 +138,18 @@ namespace Yaskawa.Ext
         {
             client.registerTranslationData(id, locale, translationData, translationName);
         }
-       public void registerUtilityWindow(string identifier, string itemtype, string menuitemname, string windowtitle) 
+
+        public void registerUtilityMenu(string menuName, string menuText, string menuIcon) 
+        {
+            client.registerUtilityMenu(id, menuName, menuText, menuIcon);
+        }
+        public void unregisterUtilityMenu(string menuName) 
+        {
+            client.unregisterUtilityMenu(id, menuName);
+        }
+       public void registerUtilityWindow(string identifier, string itemtype, string menuitemname, string windowtitle, string menuName) 
        {
-           client.registerUtilityWindow(id, identifier, itemtype, menuitemname, windowtitle);
+           client.registerUtilityWindow(id, identifier, itemtype, menuitemname, windowtitle, menuName);
        }
        public void unregisterUtilityWindow(String identifier)
        {

--- a/csharp/Yaskawa/Ext/Pendant.cs
+++ b/csharp/Yaskawa/Ext/Pendant.cs
@@ -147,9 +147,13 @@ namespace Yaskawa.Ext
         {
             client.unregisterUtilityMenu(id, menuName);
         }
-       public void registerUtilityWindow(string identifier, string itemtype, string menuitemname, string windowtitle, string menuName) 
+       public void registerUtilityWindow(string identifier, string itemtype, string menuitemname, string windowtitle) 
        {
-           client.registerUtilityWindow(id, identifier, itemtype, menuitemname, windowtitle, menuName);
+           client.registerUtilityWindow(id, identifier, itemtype, menuitemname, windowtitle);
+       }
+
+       public void registerUtilityWindowWithMenu(string identifier, string itemtype, string menuitemname, string windowtitle, string menuName){
+            client.registerUtilityWindowWithMenu(id, identifier, itemtype, menuitemname, windowtitle, menuName);
        }
        public void unregisterUtilityWindow(String identifier)
        {

--- a/extension.thrift
+++ b/extension.thrift
@@ -524,6 +524,11 @@ service Pendant
     */
     void registerUtilityWindow(1:PendantID p, 2:string identifier, 
                                3:string itemType,
+                               4:string menuItemName, 5:string windowTitle)
+                          throws (1:IllegalArgument e);
+
+    void registerUtilityWindowWithMenu(1:PendantID p, 2:string identifier, 
+                               3:string itemType,
                                4:string menuItemName, 5:string windowTitle, 6:string menuName)
                           throws (1:IllegalArgument e);
 

--- a/extension.thrift
+++ b/extension.thrift
@@ -510,15 +510,21 @@ service Pendant
     void registerTranslationData(1:PendantID p, 2:string locale, 3:binary translationData, 4:string translationName)
                           throws (1:IllegalArgument e);
 
-
+    /** Register a menu that utilities can be registered under **/
+    void registerUtilityMenu(1:PendantID p, 2:string menuName, 3:string menuText, 4:string menuIcon)
+                        throws (1:IllegalArgument e);
+    /** Unregisters a user added menu - All Utilities within the menu must be unregistered with 'unregisterUtilityWindow' first*/ 
+    void unregisterUtilityMenu(1:PendantID p, 2:string menuName)
+                        throws (1:IllegalArgument e);
     /** Register a Utility window with the UI.  
         The itemType references a previously registered YML item instantiated for the window
         UI content.
-        A main menu entry will automatically be added to the pendant UI, for opening the utility window.
+        The menuName refers to a previously registered menu that the utility will apear under on the 
+        main menu or if none is specified it will be under 'Utility'
     */
     void registerUtilityWindow(1:PendantID p, 2:string identifier, 
                                3:string itemType,
-                               4:string menuItemName, 5:string windowTitle)
+                               4:string menuItemName, 5:string windowTitle, 6:string menuName)
                           throws (1:IllegalArgument e);
 
     void unregisterUtilityWindow(1:PendantID p, 2:string identifier)

--- a/java/yaskawa/ext/Pendant.java
+++ b/java/yaskawa/ext/Pendant.java
@@ -188,10 +188,17 @@ public class Pendant
         }
     }
     
-    public void registerUtilityWindow(String identifier, String itemType, String menuItemName, String windowTitle, String menuName) throws TException
+    public void registerUtilityWindow(String identifier, String itemType, String menuItemName, String windowTitle) throws TException
     {
         synchronized(extension) {
-            client.registerUtilityWindow(id, identifier, itemType, menuItemName, windowTitle, menuName);
+            client.registerUtilityWindow(id, identifier, itemType, menuItemName, windowTitle);
+        }
+    }
+
+    public void registerUtilityWindowWithMenu(String identifier, String itemType, String menuItemName, String windowTitle, String menuName) throws TException
+    {
+        synchronized(extension) {
+            client.registerUtilityWindowWithMenu(id, identifier, itemType, menuItemName, windowTitle, menuName);
         }
     }
 

--- a/java/yaskawa/ext/Pendant.java
+++ b/java/yaskawa/ext/Pendant.java
@@ -174,12 +174,24 @@ public class Pendant
         }
     }
 
-
-
-    public void registerUtilityWindow(String identifier, String itemType, String menuItemName, String windowTitle) throws TException
+    public void registerUtilityMenu(String menuName, String menuTitle, String menuIcon) throws TException
     {
         synchronized(extension) {
-            client.registerUtilityWindow(id, identifier, itemType, menuItemName, windowTitle);
+            client.registerUtilityMenu(id, menuName, menuTitle, menuIcon);
+        }
+    }
+
+    public void unregisterUtilityMenu(String menuName) throws TException
+    {
+        synchronized(extension) {
+            client.unregisterUtilityMenu(id, menuName);
+        }
+    }
+    
+    public void registerUtilityWindow(String identifier, String itemType, String menuItemName, String windowTitle, String menuName) throws TException
+    {
+        synchronized(extension) {
+            client.registerUtilityWindow(id, identifier, itemType, menuItemName, windowTitle, menuName);
         }
     }
 


### PR DESCRIPTION
* Add method to thrift to allow for registering menus that utilities can be under.
* Add method for unregistering menus
* Update method for registering utilities to include a menuName that corresponds to a registered menu

**Example of custom menu:**
 
![image](https://github.com/Yaskawa-Global/SmartPendantSDK/assets/127866402/c2de4e4c-9b31-4af8-8c2c-9aa141272195)



**Comment from last PR**

1.) Yes it is backward compatible, I just tested this case and it registered the utility under the "Utilities" menu as expected.
2.) Yes it is forward compatible-ish. If you try and invoke one of the added methods, thrift throws an error saying it is an invalid method name. but if you call the updated "registerUtilityWindow" method with the additional parameter it just ignores the additional parameter and registers it under the "Utility" menu.
