### PR TITLE
Add integrationPoints for JobTestPanel & method for registering switches at an integration point

### DIFF
--- a/csharp/Yaskawa/Ext/Pendant.cs
+++ b/csharp/Yaskawa/Ext/Pendant.cs
@@ -174,6 +174,11 @@ namespace Yaskawa.Ext
        {
            client.unregisterIntegration(id, identifier);
        }
+
+       public void registerSwitch(String identifier, IntegrationPoint integrationPoint, String switchLabel, String offPositionLabel, String onPositionLabel, bool defaultState){
+            client.registerSwitch(id, identifier, integrationPoint, switchLabel, offPositionLabel, onPositionLabel, defaultState);
+       }
+       
         public Any property(string itemID, string name)
         {
             //Console.WriteLine(client.property(id, itemID, name).SValue);

--- a/extension.thrift
+++ b/extension.thrift
@@ -399,6 +399,7 @@ enum PendantEventType {
     Canceled,
     JoggingPanelVisibilityChanged,
     VisibleChanged,
+    IntegrationPointSwitchStateChanged,
     Other = 16384
 }
 
@@ -427,6 +428,11 @@ enum IntegrationPoint {
     SmartFrameJogPanelBottomAny = 49,
     JogPanelTopCenter = 50,
     HomeScreen = 60,
+    JobTestPanelCenter = 70,
+    JobTestPanelBottomLeft = 71,
+    JobTestPanelBottomRight = 72,
+    JobTestPanelTopLeft = 73,
+    JobTestPanelTopRight = 74,
 }
 
 
@@ -538,7 +544,7 @@ service Pendant
 
 
     /** Register UI content at the specified integration point in the pendant UI.
-        The itemType should reference a YML item previouslt registered via registerYML(). 
+        The itemType should reference a YML item previously registered via registerYML(). 
     */
     void registerIntegration(1:PendantID p, 2:string identifier, 3:IntegrationPoint integrationPoint,
                              4:string itemType, 5:string buttonLabel, 6:string buttonImage)
@@ -547,6 +553,13 @@ service Pendant
     void unregisterIntegration(1:PendantID p, 2:string identifier)
                           throws (1:IllegalArgument e);
 
+    /** Register a Switch component at the specified integraiton point in the pendant UI.
+        When the switch is toggled, it creates a PendantEvent with a type of IntegrationPointSwitchStateChanged that can be gotten via events()
+        Switches registered with registerSwitch() can be unregistered with unregisterIntegration()
+    */
+    void registerSwitch(1:PendantID p, 2:string identifier, 3:IntegrationPoint integrationPoint, 
+        4:string switchLabel, 5:string offPositionLabel, 6:string onPositionLabel, 7:bool defaultState)
+                          throws (1:IllegalArgument e);
 
     /** get property of an item by id */
     Any property(1:PendantID p, 2:string itemID, 3:string name)

--- a/java/yaskawa/ext/Pendant.java
+++ b/java/yaskawa/ext/Pendant.java
@@ -234,6 +234,12 @@ public class Pendant
         }
     }
 
+    public void registerSwitch(String identifier, IntegrationPoint integrationPoint, String switchLabel, String offPositionLabel, String onPositionLabel, boolean defaultState) throws IllegalArgument, TException
+    {
+        synchronized(extension) {
+            client.registerSwitch(id, identifier, integrationPoint, switchLabel, offPositionLabel, onPositionLabel, defaultState);
+        }
+    }
 
     public Any property(String itemID, String name) throws IllegalArgument, TException
     {


### PR DESCRIPTION
Thrift SDK changes for [#6226](https://dev.yaskawa.io/pendant-dev/globalpendant/-/issues/6226)
Adds New IntegrationPoints
Adds registerSwitch method to thrift