### PR TITLE
Fix null reference when accessing Robot class

### DIFF
--- a/csharp/Yaskawa/Ext/Controller.cs
+++ b/csharp/Yaskawa/Ext/Controller.cs
@@ -9,9 +9,10 @@ namespace Yaskawa.Ext
 {
     public class Controller
     {
-        internal Controller(Extension ext, TProtocol protocol, long id)
+        internal Controller(Extension ext, TProtocol protocol, TMultiplexedProtocol _robotProtocol, long id)
         {
             extension = ext;
+            robotProtocol = _robotProtocol;
             client = new API.Controller.Client(protocol);
             this.id = id;
             eventConsumers = new Dictionary<ControllerEventType, List<Action<ControllerEvent>>>();

--- a/csharp/Yaskawa/Ext/Extension.cs
+++ b/csharp/Yaskawa/Ext/Extension.cs
@@ -24,6 +24,7 @@ namespace Yaskawa.Ext
         protected TMultiplexedProtocol extensionProtocol;
         protected TMultiplexedProtocol controllerProtocol;
         protected TMultiplexedProtocol pendantProtocol;
+        protected TMultiplexedProtocol robotProtocol;
 
         protected Dictionary<long, Controller> controllerMap;
         protected Dictionary<long, Pendant> pendantMap;
@@ -83,6 +84,7 @@ namespace Yaskawa.Ext
             extensionProtocol = new TMultiplexedProtocol(protocol, "Extension");
             controllerProtocol = new TMultiplexedProtocol(protocol, "Controller");
             pendantProtocol = new TMultiplexedProtocol(protocol, "Pendant");
+            robotProtocol = new TMultiplexedProtocol(protocol, "Robot");
 
             client = new API.Extension.Client(extensionProtocol);
 
@@ -136,7 +138,7 @@ namespace Yaskawa.Ext
         {
             var cid = client.controller(id);
             if (!controllerMap.ContainsKey(cid))
-                controllerMap[cid] = new Controller(this, controllerProtocol, cid);
+                controllerMap[cid] = new Controller(this, controllerProtocol, robotProtocol, cid);
 
             return controllerMap[cid];
         }


### PR DESCRIPTION
@davidljung 
This now matches the java implementation.

Resolves error `Value cannot be null. (Parameter 'inputProtocol')`