### PR TITLE
Change m-register types to i32

### DIFF
--- a/csharp/Yaskawa/Ext/Controller.cs
+++ b/csharp/Yaskawa/Ext/Controller.cs
@@ -350,12 +350,12 @@ namespace Yaskawa.Ext
             client.setNetworkInputAddress(id, address, value);
         }
 
-        public int mRegisterValue(int index){
-            return client.mRegisterValue(id,index);
+        public ushort mRegisterValue(int index){
+            return (ushort)client.mRegisterValue(id, index);
         }
 
-        public void setMRegisterIndex(int index, short value){
-            client.setMRegisterIndex(id,index, value);
+        public void setMRegisterIndex(int index, ushort value){
+            client.setMRegisterIndex(id,index, (int)value);
         }
 
         public int fieldBusStatusInputGroup(String busType)

--- a/csharp/Yaskawa/Ext/Controller.cs
+++ b/csharp/Yaskawa/Ext/Controller.cs
@@ -354,8 +354,8 @@ namespace Yaskawa.Ext
             return (ushort)client.mRegisterValue(id, index);
         }
 
-        public void setMRegisterIndex(int index, ushort value){
-            client.setMRegisterIndex(id,index, (int)value);
+        public void setMRegisterValue(int index, ushort value){
+            client.setMRegisterValue(id,index, (int)value);
         }
 
         public int fieldBusStatusInputGroup(String busType)

--- a/extension.thrift
+++ b/extension.thrift
@@ -1260,13 +1260,11 @@ service Controller
     Note it is asyncronous so no errors/exceptions are thrown (SDK 3.1+)*/
     oneway void setNetworkInputAddress(1:ControllerID c, 2:i32 address, 3:bool value);
 
-	/** Return the value of the given M-Register 
-        (API version 3.2 and later)
-    */
+	/** Return the value of the given M-Register (SDK 3.1+) */
     i32 mRegisterValue(1:ControllerID c, 2:i32 index) throws (1:IllegalArgument e);
     /** Set the value of the given M-Register by index
     Note it is asynchronous so no errors/exceptions are thrown.(SDK 3.1+) */
-    oneway void setMRegisterIndex(1:ControllerID c, 2:i32 index, 3:i32 value);
+    oneway void setMRegisterValue(1:ControllerID c, 2:i32 index, 3:i32 value);
 
     // FieldBus Protocols
 

--- a/extension.thrift
+++ b/extension.thrift
@@ -1263,10 +1263,10 @@ service Controller
 	/** Return the value of the given M-Register 
         (API version 3.2 and later)
     */
-    i16 mRegisterValue(1:ControllerID c, 2:i32 index) throws (1:IllegalArgument e);
+    i32 mRegisterValue(1:ControllerID c, 2:i32 index) throws (1:IllegalArgument e);
     /** Set the value of the given M-Register by index
-    Note it is asynchronous so no errors/exceptions are thrown.*/
-    oneway void setMRegisterIndex(1:ControllerID c, 2:i32 index, 3:i16 value);
+    Note it is asynchronous so no errors/exceptions are thrown.(SDK 3.1+) */
+    oneway void setMRegisterIndex(1:ControllerID c, 2:i32 index, 3:i32 value);
 
     // FieldBus Protocols
 

--- a/java/yaskawa/ext/Controller.java
+++ b/java/yaskawa/ext/Controller.java
@@ -518,10 +518,10 @@ public class Controller
         }
     }
 
-    public void setMRegisterIndex(int index, int value) throws TException
+    public void setMRegisterValue(int index, int value) throws TException
     {
         synchronized(extension){
-            client.setMRegisterIndex(id, index, value);
+            client.setMRegisterValue(id, index, value);
         }
     }
  

--- a/java/yaskawa/ext/Controller.java
+++ b/java/yaskawa/ext/Controller.java
@@ -518,7 +518,7 @@ public class Controller
         }
     }
 
-    public void setMRegisterIndex(int index, short value) throws TException
+    public void setMRegisterIndex(int index, int value) throws TException
     {
         synchronized(extension){
             client.setMRegisterIndex(id, index, value);


### PR DESCRIPTION
change mregisterValue and setMregister thrift methods to use i32 for the data values returned by thrift & sent to thrift. In the c# it is cast to a ushort for convenience, but java does not have an equivalent so it remains an int